### PR TITLE
Fixed tomuss parser (we broke it again)

### DIFF
--- a/packages/lyon1tomussclient/lib/src/model/url.dart
+++ b/packages/lyon1tomussclient/lib/src/model/url.dart
@@ -20,7 +20,7 @@ class URL extends TeachingUnitElement {
       value = json["empty_is"];
     } else {
       value = "";
-      print("Couldn't find url in URL object...");
+      throw ("Couldn't find url in URL object...");
     }
   }
 

--- a/packages/lyon1tomussclient/lib/src/model/url.dart
+++ b/packages/lyon1tomussclient/lib/src/model/url.dart
@@ -13,8 +13,8 @@ class URL extends TeachingUnitElement {
   URL.fromJSON(var id, Map json, var stats, var line, var column, String user)
       : super.fromJson(id, json, stats, line, column, user) {
 
-    List props =  line[id];
-    if (props.isNotEmpty) {
+    var props = line[id];
+    if (props is List && props.isNotEmpty) {
       value = props[0].toString();
     } else if (json.containsKey("empty_is")) {
       value = json["empty_is"];

--- a/packages/lyon1tomussclient/lib/src/model/url.dart
+++ b/packages/lyon1tomussclient/lib/src/model/url.dart
@@ -10,9 +10,18 @@ class URL extends TeachingUnitElement {
   @HiveField(2, defaultValue: "")
   late final String value;
 
-  URL.fromJSON(var id, var json, var stats, var line, var column, String user)
+  URL.fromJSON(var id, Map json, var stats, var line, var column, String user)
       : super.fromJson(id, json, stats, line, column, user) {
-    value = line[id][0].toString();
+
+    List props =  line[id];
+    if (props.isNotEmpty) {
+      value = props[0].toString();
+    } else if (json.containsKey("empty_is")) {
+      value = json["empty_is"];
+    } else {
+      value = "";
+      print("Couldn't find url in URL object...");
+    }
   }
 
   URL({

--- a/packages/lyon1tomussclient/lib/src/model/url.dart
+++ b/packages/lyon1tomussclient/lib/src/model/url.dart
@@ -19,7 +19,6 @@ class URL extends TeachingUnitElement {
     } else if (json.containsKey("empty_is")) {
       value = json["empty_is"];
     } else {
-      value = "";
       throw ("Couldn't find url in URL object...");
     }
   }


### PR DESCRIPTION
It couldn't extract the url when it was located in the "empty_is" field (why is it even here ??)